### PR TITLE
Support new version of tuned-adm binary

### DIFF
--- a/salt/modules/tuned.py
+++ b/salt/modules/tuned.py
@@ -45,9 +45,13 @@ def list_():
     '''
 
     result = __salt__['cmd.run']('tuned-adm list').splitlines()
+    # Remove "Available profiles:"
     result.pop(0)
+    # Remove "Current active profile:.*"
     result.pop()
-    result = [i.lstrip('- ') for i in result]
+    # Output can be : " - <profile name> - <description>" (v2.7.1)
+    # or " - <profile name> " (v2.4.1)
+    result = [i.split('-')[1].strip() for i in result]
     return result
 
 


### PR DESCRIPTION
Hi,

### What does this PR do?
This support the new version of tuned-adm that comes in centos 7.3

### What issues does this PR fix or reference?
#39692

### Previous Behavior
Output parsing was only working with tuned-adm 2.4.1

### New Behavior
Output parsing in working for 2.4.1 and 2.7.1

### Tests written?
No: I beleive the code is only reach with tuned-adm call. I try on my side with the new and old version
Tell me if you want something more

Regards